### PR TITLE
Improvements in `MemoryStreamReader`

### DIFF
--- a/Shared/MessagePack/Dto/ArraySegment.cs
+++ b/Shared/MessagePack/Dto/ArraySegment.cs
@@ -183,7 +183,7 @@ namespace nanoFramework.MessagePack.Dto
         public class ArraySegmentEnumerator : IEnumerator
         {
             private int _position = -1;
-            private ArraySegment _arraySegment;
+            private readonly ArraySegment _arraySegment;
 
             internal ArraySegmentEnumerator(ArraySegment arraySegment)
             {

--- a/Shared/MessagePack/Stream/MemoryStreamReader.cs
+++ b/Shared/MessagePack/Stream/MemoryStreamReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NANOFRAMEWORK_1_0
@@ -61,28 +61,28 @@ namespace nanoFramework.MessagePack.Stream
 #nullable enable
         protected override ArraySegment? StopTokenGathering()
         {
-            if (_stream.Position <= _stream.Length)
+            if (_stream.Position <= _stream.Length && _gatheringStartPosition >= 0)
             {
                 long currentPosition = _stream.Position;
                 long bytesGathered = currentPosition - _gatheringStartPosition;
-                
-                byte[] result = new byte[bytesGathered];
-                
-                _stream.Position = _gatheringStartPosition;
-                _stream.Read(result, 0, result.Length);
-                _stream.Position = currentPosition;
 
-                return new ArraySegment(result, 0, result.Length);
+                if (bytesGathered > 0)
+                {
+                    _stream.Position = _gatheringStartPosition;
+                    byte[] result = ReadBytesInternal((uint)bytesGathered);
+                    _stream.Position = currentPosition;
+
+                    return new ArraySegment(result, 0, result.Length);
+                }
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
+            
         }
 
         protected override void StartTokenGathering()
         {
-            _gatheringStartPosition = _stream.Position;
+            _gatheringStartPosition = _stream.Position; 
         }
     }
 }

--- a/Shared/MessagePack/Stream/MemoryStreamReader.cs
+++ b/Shared/MessagePack/Stream/MemoryStreamReader.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 #endif
-using System.Collections;
 using nanoFramework.MessagePack.Dto;
 using nanoFramework.MessagePack.Utility;
 
@@ -14,15 +13,11 @@ namespace nanoFramework.MessagePack.Stream
     internal sealed class MemoryStreamReader : BaseReader, IDisposable
     {
         private readonly MemoryStream _stream;
-        private readonly ArrayList _bytesGatheringBuffer;
-
-        private long _bytesGatheringBufferLength = 0;
-        private bool _bytesGatheringInProgress;
+        private long _gatheringStartPosition;
 
         public MemoryStreamReader(MemoryStream stream)
         {
             _stream = stream;
-            _bytesGatheringBuffer = new ArrayList();
         }
 
         public override byte ReadByte()
@@ -33,42 +28,18 @@ namespace nanoFramework.MessagePack.Stream
                 throw ExceptionUtility.NotEnoughBytes(0, 1);
             }
 
-            var result = (byte)temp;
-            if (_bytesGatheringInProgress)
-            {
-                _bytesGatheringBuffer.Add(new byte[] { result });
-                _bytesGatheringBufferLength++;
-            }
-
-            return result;
+            return (byte)temp;
         }
 
         public override ArraySegment ReadBytes(uint length)
         {
             var buffer = ReadBytesInternal(length);
-
-            if (_bytesGatheringInProgress)
-            {
-                _bytesGatheringBuffer.Add(buffer);
-                _bytesGatheringBufferLength += buffer.Length;
-            }
-
             return buffer;
         }
 
         public override void Seek(long offset, SeekOrigin origin)
         {
-            if (_bytesGatheringInProgress)
-            {
-                var buffer = ReadBytesInternal((uint)offset);
-
-                _bytesGatheringBuffer.Add(buffer);
-                _bytesGatheringBufferLength += buffer.Length;
-            }
-            else
-            {
-                _stream.Seek(offset, origin);
-            }
+            _stream.Seek(offset, origin);
         }
 
         public void Dispose()
@@ -92,16 +63,14 @@ namespace nanoFramework.MessagePack.Stream
         {
             if (_stream.Position <= _stream.Length)
             {
-                _bytesGatheringInProgress = false;
-
-                byte[] result = new byte[_bytesGatheringBufferLength];
-
-                int destinationOffset = 0;
-                foreach (byte[] part in _bytesGatheringBuffer)
-                {
-                    Array.Copy(part, 0, result, destinationOffset, part.Length);
-                    destinationOffset += part.Length;
-                }
+                long currentPosition = _stream.Position;
+                long bytesGathered = currentPosition - _gatheringStartPosition;
+                
+                byte[] result = new byte[bytesGathered];
+                
+                _stream.Position = _gatheringStartPosition;
+                _stream.Read(result, 0, result.Length);
+                _stream.Position = currentPosition;
 
                 return new ArraySegment(result, 0, result.Length);
             }
@@ -113,9 +82,7 @@ namespace nanoFramework.MessagePack.Stream
 
         protected override void StartTokenGathering()
         {
-            _bytesGatheringInProgress = true;
-            _bytesGatheringBuffer.Clear();
-            _bytesGatheringBufferLength = 0;
+            _gatheringStartPosition = _stream.Position;
         }
     }
 }


### PR DESCRIPTION
Removed unnecessary memory allocation and copying.

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
The MemoryStreamReader class has suboptimal memory handling, with unnecessary allocation and copying.

## Motivation and Context
More efficient memory management will speed up the process of deserialization from the stream.
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The modified code was already covered by tests earlier.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
